### PR TITLE
Правила Next добавлены в конфиг ESlint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,13 @@
     "sourceType": "module",
     "project": ["tsconfig.json", "tsconfig.jest.json", "tsconfig.cypress.json"]
   },
-  "extends": ["airbnb-ts", "airbnb/hooks", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "airbnb-ts",
+    "airbnb/hooks",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@next/next/recommended",
+    "next/core-web-vitals"
+  ],
   "rules": {
     "quotes": ["error", "double"],
     "semi": ["error", "never"],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next build && next start",
     "dev": "next dev",
     "lint": "concurrently -c green \"npm:lint:*\"",
-    "lint:ts": "eslint --ext .ts,.tsx .",
+    "lint:next": "next lint",
     "lint:typecheck": "tsc --noEmit --project tsconfig.json",
     "test": "concurrently -c green \"npm:test:*\"",
     "test:unit": "jest",


### PR DESCRIPTION
## Описание изменений

- Правила Next добавлены в конфиг ESlint
- При сборке Next запускает ESlint
- Вместо обычного `"extends": ["next"]` использован "plugin:@next/next/recommended" как сказано [тут](https://nextjs.org/docs/basic-features/eslint#migrating-existing-config)
- "next/core-web-vitals" тоже не забыт (пока он только делает из warning'ов ошибки, как я понял)
