### PR TITLE
Tесты в Github actions теперь запускаются из ветки PR, а не main

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,5 +1,5 @@
 name: Run Jest tests
-on: [pull_request_target]
+on: [pull_request]
 
 jobs:
   build-test:


### PR DESCRIPTION
## Описание изменений

До сего момента тесты, которые запускались в Github Action были невалидны: она запускались из main ветки, а не из ветки PR. Поправлено

## Чеклист

- [ ] Обновлена документация в docs/
- [ ] Обновлена документация проекта в Notion
