### PR TITLE
Мелко-фиксы из base-fullstack

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,6 +40,14 @@
         "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"
       }
+    ],
+    "jsx-a11y/anchor-is-valid": [
+      "error",
+      {
+        "components": ["Link"],
+        "specialLink": ["hrefLeft", "hrefRight"],
+        "aspects": ["invalidHref", "preferButton"]
+      }
     ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,7 @@
   ],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "paths": {
-      "components/*": ["src/components/*"],
-      "hooks/*": ["src/hooks/*"],
-      "pages/*": ["src/pages/*"],
-      "styles/*": ["src/styles/*"]
-    },
-    "baseUrl": ".",
+    "baseUrl": "src",
     "moduleResolution": "node",
     "module": "commonjs",
     "jsx": "preserve",


### PR DESCRIPTION
## Описание изменений

В процессе создания base-fullstack были замечены пара косяков в base-frontend:

- в `tsconfig.json` теперь просто прописан `baseUrl`, вместо того, чтобы описывать каждую папку в src
- пофикшено eslint правило `jsx-a11y/anchor-is-valid`, теперь оно не ругается на NextLink

## Чеклист

- [x] Всё проверено
- [x] Self-review
